### PR TITLE
Major refactoring #2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,11 @@ Style/AndOr:
 Style/BlockDelimiters:
   Enabled: true
   EnforcedStyle: semantic
+  IgnoredMethods:
+    - lambda
+    - proc
+    - it
+    - link
 
 Style/Lambda:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem 'roar', github: 'trailblazer/roar', branch: 'master'
 gem 'minitest-line'
 gem 'minitest-reporters'
 gem 'pry'
+
+gem 'json_spec', require: nil

--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,6 @@ class SongsRepresenter < Roar::Decorator
   include Roar::JSON::JSONAPI
   type :songs
 
-  property :id
   property :title
 end
 ```
@@ -67,7 +66,6 @@ class SongsRepresenter < Roar::Decorator
 
 compound do
   property :album do
-    property :id
     property :title
   end
 

--- a/lib/roar/json/json_api/declarative.rb
+++ b/lib/roar/json/json_api/declarative.rb
@@ -42,12 +42,11 @@ module Roar
         private
 
         def has_relationship(name, options = {}, &block)
-          resource_decorator = options.fetch(:decorator) {
-            blank_decorator = Class.new(Roar::Decorator)
-            blank_decorator.send(:include, Roar::JSON::JSONAPI)
-            blank_decorator.instance_exec(&block)
-            blank_decorator
-          }
+          resource_decorator = options[:decorator] || options[:extends] ||
+                               Class.new(Roar::Decorator).tap { |decorator|
+                                 decorator.send(:include, Roar::JSON::JSONAPI)
+                               }
+          resource_decorator.instance_exec(&block)
 
           resource_identifier_representer = Class.new(resource_decorator)
           resource_identifier_representer.class_eval do

--- a/lib/roar/json/json_api/declarative.rb
+++ b/lib/roar/json/json_api/declarative.rb
@@ -10,6 +10,10 @@ module Roar
           @type = name.to_s
         end
 
+        def attributes(&block)
+          nested(:attributes, inherit: true, &block)
+        end
+
         def link(name, options = {}, &block)
           return super(name, &block) unless options[:toplevel]
           for_collection.link(name, &block)
@@ -20,7 +24,12 @@ module Roar
           for_collection.meta(&block)
         end
 
-        def relationship(options = {}, &block); end
+        def relationship(&block)
+          return (@relationship ||= -> {}) unless block
+
+          heritage.record(:relationship, &block)
+          @relationship = block
+        end
 
         def has_one(name, options = {}, &block)
           has_relationship(name, options.merge(collection: false), &block)
@@ -33,41 +42,24 @@ module Roar
         private
 
         def has_relationship(name, options = {}, &block)
-          # every nested representer is a full-blown JSONAPI representer.
-          nested(:included, inherit: true) do
-            property(name, collection: options[:collection]) {
-              include Roar::JSON::JSONAPI
+          resource_decorator = options.fetch(:decorator) {
+            blank_decorator = Class.new(Roar::Decorator)
+            blank_decorator.send(:include, Roar::JSON::JSONAPI)
+            blank_decorator.instance_exec(&block)
+            blank_decorator
+          }
 
-              instance_exec(&block)
-
-              def from_document(hash)
-                hash
-              end
-            }
+          resource_identifier_representer = Class.new(resource_decorator)
+          resource_identifier_representer.class_eval do
+            def to_hash(_options = {})
+              super(include: [:id, :meta], wrap: false)
+            end
           end
 
-          resource_identifier_representer = Class.new(Roar::Decorator)
-          resource_identifier_representer.class_eval do
-            include Roar::JSON
-            include Roar::Hypermedia
-            include JSONAPI::Meta
-            extend JSONAPI::Declarative
-
-            def self.relationship_block
-              @relationship_block ||= -> {}
-            end
-
-            def self.relationship(&block)
-              @relationship_block = block
-            end
-
-            instance_exec(&block)
-
-            def to_hash(_options)
-              hash = { 'type' => self.class.type }.merge(super(include: [:id, :meta]))
-              hash['id'] = hash['id'].to_s
-              hash
-            end
+          nested(:included, inherit: true) do
+            property(name, collection: options[:collection],
+                           decorator:  resource_decorator,
+                           wrap:       false)
           end
 
           nested(:relationships, inherit: true) do
@@ -89,17 +81,18 @@ module Roar
                                            },
                                            render_nil:   true,
                                            render_empty: true,
-                                           decorator:    resource_identifier_representer)
+                                           decorator:    resource_identifier_representer,
+                                           wrap:         false)
 
-              instance_exec(&resource_identifier_representer.relationship_block)
+              instance_exec(&resource_identifier_representer.relationship)
 
               def to_hash(*)
                 hash  = super
                 links = Renderer::Links.new.(hash, {})
                 meta  = render_meta({})
 
-                Fragment::Links.(hash, links, {})
-                Fragment::Meta.(hash, meta, {})
+                HashUtils.store_if_any(hash, 'links', links)
+                HashUtils.store_if_any(hash, 'meta',  meta)
 
                 hash
               end

--- a/lib/roar/json/json_api/declarative.rb
+++ b/lib/roar/json/json_api/declarative.rb
@@ -85,6 +85,7 @@ module Roar
 
               instance_exec(&resource_identifier_representer.relationship)
 
+              # rubocop:disable Lint/NestedMethodDefinition
               def to_hash(*)
                 hash  = super
                 links = Renderer::Links.new.(hash, {})
@@ -95,6 +96,7 @@ module Roar
 
                 hash
               end
+              # rubocop:enable Lint/NestedMethodDefinition
             end
           end
         end

--- a/lib/roar/json/json_api/document.rb
+++ b/lib/roar/json/json_api/document.rb
@@ -23,62 +23,27 @@ module Roar
 
       module Document
         def to_hash(options = {})
-          res = super(Options::Include.(options, self))
+          document  = super(Options::Include.(options, self))
+          unwrapped = options[:wrap] == false
+          resource  = unwrapped ? document : document['data']
+          resource['type'] = self.class.type
 
-          links = Renderer::Links.new.(res, options)
+          links = Renderer::Links.new.(resource, options)
           meta  = render_meta(options)
 
-          relationships = render_relationships(res)
-          included      = render_included(res)
+          resource.reject! do |_, v| v && v.empty? end
 
-          document = {
-            'data' => data = {
-              'type' => self.class.type,
-              'id'   => res.delete('id').to_s
-            }
-          }
-          data['attributes']    = res unless res.empty?
-          data['relationships'] = relationships if relationships && relationships.any?
+          unless unwrapped
+            included = resource.delete('included')
 
-          Fragment::Links.(data, links, options)
-          Fragment::Included.(document, included, options)
-          Fragment::Meta.(document, meta, options)
+            HashUtils.store_if_any(document, 'included',
+                                   Fragment::Included.(included, options))
+          end
+
+          HashUtils.store_if_any(resource, 'links', links)
+          HashUtils.store_if_any(document, 'meta',  meta)
 
           document
-        end
-
-        def from_hash(hash, _options = {})
-          super(from_document(hash))
-        end
-
-        private
-
-        def from_document(hash)
-          return {} unless hash['data'] # DISCUSS: Is failing silently here a good idea?
-          # hash: {"data"=>{"type"=>"articles", "attributes"=>{"title"=>"Ember Hamster"}, "relationships"=>{"author"=>{"data"=>{"type"=>"people", "id"=>"9"}}}}}
-          attributes = hash['data']['attributes'] || {}
-          attributes['relationships'] = hash['data'].fetch('relationships', {})
-
-          # this is the format the object representer understands.
-          attributes # {"title"=>"Ember Hamster", "author"=>{"type"=>"people", "id"=>"9"}}
-        end
-
-        # Go through {"album"=>{"title"=>"Hackers"}, "musicians"=>[{"name"=>"Eddie Van Halen"}, ..]} from linked:
-        # and wrap every item in an array.
-        def render_included(res)
-          return unless (compound = res.delete('included'))
-
-          compound.collect { |_name, hash|
-            if hash.is_a?(::Hash)
-              hash['data']
-            else
-              hash.collect { |item| item['data'] }
-            end
-          }.flatten
-        end
-
-        def render_relationships(res)
-          res.delete('relationships')
         end
       end
     end

--- a/lib/roar/json/json_api/document.rb
+++ b/lib/roar/json/json_api/document.rb
@@ -22,6 +22,7 @@ module Roar
       end
 
       module Document
+        # rubocop:disable Metrics/MethodLength
         def to_hash(options = {})
           document  = super(Options::Include.(options, self))
           unwrapped = options[:wrap] == false
@@ -45,6 +46,7 @@ module Roar
 
           document
         end
+        # rubocop:enable Metrics/MethodLength
       end
     end
   end

--- a/lib/roar/json/json_api/for_collection.rb
+++ b/lib/roar/json/json_api/for_collection.rb
@@ -8,6 +8,8 @@ module Roar
           nested_builder.(_base: default_nested_class, _features: [Roar::JSON, Roar::Hypermedia, JSONAPI::Meta], _block: proc do
             collection :to_a, as: :data, decorator: singular, wrap: false
 
+            # rubocop:disable Metrics/MethodLength
+            # rubocop:disable Lint/NestedMethodDefinition
             def to_hash(options = {})
               document = super(to_a: options, user_options: options[:user_options]) # [{data: {..}, data: {..}}]
 
@@ -25,6 +27,8 @@ module Roar
 
               document
             end
+            # rubocop:enable Lint/NestedMethodDefinition
+            # rubocop:enable Metrics/MethodLength
           end)
         end
       end

--- a/lib/roar/json/json_api/for_collection.rb
+++ b/lib/roar/json/json_api/for_collection.rb
@@ -2,31 +2,26 @@ module Roar
   module JSON
     module JSONAPI
       module ForCollection
-        def collection_representer!(_options) # FIXME: cache.
+        def collection_representer!(_options)
           singular = self # e.g. Song::Representer
 
-          # this basically does Module.new { include Hash::Collection .. }
           nested_builder.(_base: default_nested_class, _features: [Roar::JSON, Roar::Hypermedia, JSONAPI::Meta], _block: proc do
-            collection :to_a, decorator: singular # render/parse every item using the singular representer.
-
-            # toplevel links are defined here, as in
-            # link(:self) { .. }
+            collection :to_a, as: :data, decorator: singular, wrap: false
 
             def to_hash(options = {})
-              hash = super(to_a: options, user_options: options[:user_options]) # [{data: {..}, data: {..}}]
-              collection = hash['to_a']
-              meta       = render_meta(options)
+              document = super(to_a: options, user_options: options[:user_options]) # [{data: {..}, data: {..}}]
 
-              document = { 'data' => [] }
+              links = Renderer::Links.new.(document, options)
+              meta  = render_meta(options)
               included = []
-              collection.each do |single|
-                document['data'] << single['data']
+              document['data'].each do |single|
                 included += single.delete('included') || []
               end
 
-              Fragment::Links.(document, Renderer::Links.new.(hash, {}), options)
-              Fragment::Included.(document, included, options)
-              Fragment::Meta.(document, meta, options)
+              HashUtils.store_if_any(document, 'included',
+                                     Fragment::Included.(included, options))
+              HashUtils.store_if_any(document, 'links',    links)
+              HashUtils.store_if_any(document, 'meta',     meta)
 
               document
             end

--- a/test/jsonapi/collection_render_test.rb
+++ b/test/jsonapi/collection_render_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 require "roar/json/json_api"
 require "json"
-require "jsonapi/representer"
 
 class JsonapiCollectionRenderTest < MiniTest::Spec
   let (:article) { Article.new(1, "Health walk", Author.new(2), Author.new("editor:1"), [Comment.new("comment:1", "Ice and Snow"),Comment.new("comment:2", "Red Stripe Skank")])}
@@ -40,7 +39,8 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
                             'meta' => { 'comment-count' => 5 }
                           }
                         },
-                        'links'         => { 'self' => 'http://Article/1' }
+                        'links'         => { 'self' => 'http://Article/1' },
+                        'meta'          => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
                       },
                       {
                         'type'          => 'articles',
@@ -69,7 +69,8 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
                             'meta' => { 'comment-count' => 5 }
                           }
                         },
-                        'links'         => { 'self' => 'http://Article/2' }
+                        'links'         => { 'self' => 'http://Article/2' },
+                        'meta'          => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
                       },
                       {
                         'type'          => 'articles',
@@ -98,7 +99,8 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
                             'meta' => { 'comment-count' => 5 }
                           }
                         },
-                        'links'         => { 'self' => 'http://Article/3' }
+                        'links'         => { 'self' => 'http://Article/3' },
+                        'meta'          => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
                       }
                     ],
                     'links'    => { 'self' => '//articles' },
@@ -176,7 +178,8 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
                             'meta' => { 'comment-count' => 5 }
                           }
                         },
-                        'links'         => { 'self' => 'http://Article/1' }
+                        'links'         => { 'self' => 'http://Article/1' },
+                        'meta'          => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
                       },
                       {
                         'type'          => 'articles',
@@ -205,7 +208,8 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
                             'meta' => { 'comment-count' => 5 }
                           }
                         },
-                        'links'         => { 'self' => 'http://Article/2' }
+                        'links'         => { 'self' => 'http://Article/2' },
+                        'meta'          => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
                       },
                       {
                         'type'          => 'articles',
@@ -234,7 +238,8 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
                             'meta' => { 'comment-count' => 5 }
                           }
                         },
-                        'links'         => { 'self' => 'http://Article/3' }
+                        'links'         => { 'self' => 'http://Article/3' },
+                        'meta'          => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
                       }
                     ],
                     'links' => { 'self' => '//articles' },

--- a/test/jsonapi/collection_render_test.rb
+++ b/test/jsonapi/collection_render_test.rb
@@ -1,14 +1,14 @@
-require "test_helper"
-require "roar/json/json_api"
-require "json"
+require 'test_helper'
+require 'roar/json/json_api'
+require 'json'
 
 class JsonapiCollectionRenderTest < MiniTest::Spec
-  let (:article) { Article.new(1, "Health walk", Author.new(2), Author.new("editor:1"), [Comment.new("comment:1", "Ice and Snow"),Comment.new("comment:2", "Red Stripe Skank")])}
-  let (:article2) { Article.new(2, "Virgin Ska", Author.new("author:1"), nil, [Comment.new("comment:3", "Cool song!")]) }
-  let (:article3) { Article.new(3, "Gramo echo", Author.new("author:1"), nil, [Comment.new("comment:4", "Skalar")]) }
-  let (:decorator) { ArticleDecorator.for_collection.new([article, article2, article3]) }
+  let(:article) { Article.new(1, 'Health walk', Author.new(2), Author.new('editor:1'), [Comment.new('comment:1', 'Ice and Snow'), Comment.new('comment:2', 'Red Stripe Skank')]) }
+  let(:article2) { Article.new(2, 'Virgin Ska', Author.new('author:1'), nil, [Comment.new('comment:3', 'Cool song!')]) }
+  let(:article3) { Article.new(3, 'Gramo echo', Author.new('author:1'), nil, [Comment.new('comment:4', 'Skalar')]) }
+  let(:decorator) { ArticleDecorator.for_collection.new([article, article2, article3]) }
 
-  it "renders full document" do
+  it 'renders full document' do
     json = decorator.to_json
     json.must_equal_json(%({
       "data": [{
@@ -211,7 +211,7 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
     }))
   end
 
-  it "included: false suppresses compound docs" do
+  it 'included: false suppresses compound docs' do
     json = decorator.to_json(included: false)
     json.must_equal_json(%({
       "data": [{
@@ -362,16 +362,14 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
     }))
   end
 
-  it "passes :user_options to toplevel links when rendering" do
+  it 'passes :user_options to toplevel links when rendering' do
     hash = decorator.to_hash(user_options: { page: 2, per_page: 10 })
-    hash['links'].must_equal({
-      "self" => "//articles?page=2&per_page=10"
-    })
+    hash['links'].must_equal('self' => '//articles?page=2&per_page=10')
   end
 
   it 'renders additional meta information if meta option supplied' do
     hash = decorator.to_hash('meta' => { page: 2, total: 9 })
-    hash['meta'].must_equal("count" => 3, page: 2, total: 9)
+    hash['meta'].must_equal('count' => 3, page: 2, total: 9)
   end
 
   it 'does not render additional meta information if meta option is empty' do
@@ -380,7 +378,7 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
     hash['meta'][:total].must_be_nil
   end
 
-  describe "Fetching Resources (empty collection)" do
+  describe 'Fetching Resources (empty collection)' do
     let(:document) {
       %({
         "data": [],

--- a/test/jsonapi/collection_render_test.rb
+++ b/test/jsonapi/collection_render_test.rb
@@ -9,241 +9,357 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
   let (:decorator) { ArticleDecorator.for_collection.new([article, article2, article3]) }
 
   it "renders full document" do
-    hash = decorator.to_hash
-    hash.must_equal('data'     => [
-                      {
-                        'type'          => 'articles',
-                        'id'            => '1',
-                        'attributes'    => { 'title' => 'Health walk' },
-                        'relationships' => {
-                          'author'   => {
-                            'data'  => { 'type' => 'authors', 'id' => '2' },
-                            'links' => {
-                              'self'    => '/articles/1/relationships/author',
-                              'related' => '/articles/1/author'
-                            }
-                          },
-                          'editor'   => {
-                            'data' => { 'type' => 'editors', 'id' => 'editor:1' },
-                            'meta' => { 'peer_reviewed' => false }
-                          },
-                          'comments' => {
-                            'data'  => [
-                              { 'type' => 'comments', 'id' => 'comment:1' },
-                              { 'type' => 'comments', 'id' => 'comment:2' }
-                            ],
-                            'links' => {
-                              'self'    => '/articles/1/relationships/comments',
-                              'related' => '/articles/1/comments'
-                            },
-                            'meta' => { 'comment-count' => 5 }
-                          }
-                        },
-                        'links'         => { 'self' => 'http://Article/1' },
-                        'meta'          => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
-                      },
-                      {
-                        'type'          => 'articles',
-                        'id'            => '2',
-                        'attributes'    => { 'title' => 'Virgin Ska' },
-                        'relationships' => {
-                          'author'   => {
-                            'data'  => { 'type' => 'authors', 'id' => 'author:1' },
-                            'links' => {
-                              'self'    => '/articles/2/relationships/author',
-                              'related' => '/articles/2/author'
-                            }
-                          },
-                          'editor'   => {
-                            'data' => nil,
-                            'meta' => { 'peer_reviewed' => false }
-                          },
-                          'comments' => {
-                            'data'  => [
-                              { 'type' => 'comments', 'id' => 'comment:3' }
-                            ],
-                            'links' => {
-                              'self'    => '/articles/2/relationships/comments',
-                              'related' => '/articles/2/comments'
-                            },
-                            'meta' => { 'comment-count' => 5 }
-                          }
-                        },
-                        'links'         => { 'self' => 'http://Article/2' },
-                        'meta'          => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
-                      },
-                      {
-                        'type'          => 'articles',
-                        'id'            => '3',
-                        'attributes'    => { 'title' => 'Gramo echo' },
-                        'relationships' => {
-                          'author'   => {
-                            'data'  => { 'type' => 'authors', 'id' => 'author:1' },
-                            'links' => {
-                              'self'    => '/articles/3/relationships/author',
-                              'related' => '/articles/3/author'
-                            }
-                          },
-                          'editor'   => {
-                            'data' => nil,
-                            'meta' => { 'peer_reviewed' => false }
-                          },
-                          'comments' => {
-                            'data'  => [
-                              { 'type' => 'comments', 'id' => 'comment:4' }
-                            ],
-                            'links' => {
-                              'self'    => '/articles/3/relationships/comments',
-                              'related' => '/articles/3/comments'
-                            },
-                            'meta' => { 'comment-count' => 5 }
-                          }
-                        },
-                        'links'         => { 'self' => 'http://Article/3' },
-                        'meta'          => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
-                      }
-                    ],
-                    'links'    => { 'self' => '//articles' },
-                    'meta'     => { 'count' => 3 },
-                    'included' => [
-                      {
-                        'type'  => 'authors',
-                        'id'    => '2',
-                        'links' => { 'self' => 'http://authors/2' }
-                      },
-                      {
-                        'type' => 'editors',
-                        'id'   => 'editor:1'
-                      },
-                      {
-                        'type'       => 'comments',
-                        'id'         => 'comment:1',
-                        'attributes' => { 'body' => 'Ice and Snow' },
-                        'links'      => { 'self' => 'http://comments/comment:1' }
-                      },
-                      {
-                        'type'       => 'comments',
-                        'id'         => 'comment:2',
-                        'attributes' => { 'body' => 'Red Stripe Skank' },
-                        'links'      => { 'self' => 'http://comments/comment:2' }
-                      },
-                      {
-                        'type'  => 'authors',
-                        'id'    => 'author:1',
-                        'links' => { 'self' => 'http://authors/author:1' }
-                      },
-                      {
-                        'type'       => 'comments',
-                        'id'         => 'comment:3',
-                        'attributes' => { 'body' => 'Cool song!' },
-                        'links'      => { 'self' => 'http://comments/comment:3' }
-                      },
-                      {
-                        'type'       => 'comments',
-                        'id'         => 'comment:4',
-                        'attributes' => { 'body' => 'Skalar' },
-                        'links'      => { 'self' => 'http://comments/comment:4' }
-                      }
-                    ])
+    json = decorator.to_json
+    json.must_equal_json(%({
+      "data": [{
+        "type": "articles",
+        "id": "1",
+        "attributes": {
+          "title": "Health walk"
+        },
+        "relationships": {
+          "author": {
+            "data": {
+              "type": "authors",
+              "id": "2"
+            },
+            "links": {
+              "self": "/articles/1/relationships/author",
+              "related": "/articles/1/author"
+            }
+          },
+          "editor": {
+            "data": {
+              "type": "editors",
+              "id": "editor:1"
+            },
+            "meta": {
+              "peer_reviewed": false
+            }
+          },
+          "comments": {
+            "data": [{
+              "type": "comments",
+              "id": "comment:1"
+            }, {
+              "type": "comments",
+              "id": "comment:2"
+            }],
+            "links": {
+              "self": "/articles/1/relationships/comments",
+              "related": "/articles/1/comments"
+            },
+            "meta": {
+              "comment-count": 5
+            }
+          }
+        },
+        "links": {
+          "self": "http://Article/1"
+        },
+        "meta": {
+          "reviewers": ["Christian Bernstein"],
+          "reviewer_initials": "C.B."
+        }
+      }, {
+        "type": "articles",
+        "id": "2",
+        "attributes": {
+          "title": "Virgin Ska"
+        },
+        "relationships": {
+          "author": {
+            "data": {
+              "type": "authors",
+              "id": "author:1"
+            },
+            "links": {
+              "self": "/articles/2/relationships/author",
+              "related": "/articles/2/author"
+            }
+          },
+          "editor": {
+            "data": null,
+            "meta": {
+              "peer_reviewed": false
+            }
+          },
+          "comments": {
+            "data": [{
+              "type": "comments",
+              "id": "comment:3"
+            }],
+            "links": {
+              "self": "/articles/2/relationships/comments",
+              "related": "/articles/2/comments"
+            },
+            "meta": {
+              "comment-count": 5
+            }
+          }
+        },
+        "links": {
+          "self": "http://Article/2"
+        },
+        "meta": {
+          "reviewers": ["Christian Bernstein"],
+          "reviewer_initials": "C.B."
+        }
+      }, {
+        "type": "articles",
+        "id": "3",
+        "attributes": {
+          "title": "Gramo echo"
+        },
+        "relationships": {
+          "author": {
+            "data": {
+              "type": "authors",
+              "id": "author:1"
+            },
+            "links": {
+              "self": "/articles/3/relationships/author",
+              "related": "/articles/3/author"
+            }
+          },
+          "editor": {
+            "data": null,
+            "meta": {
+              "peer_reviewed": false
+            }
+          },
+          "comments": {
+            "data": [{
+              "type": "comments",
+              "id": "comment:4"
+            }],
+            "links": {
+              "self": "/articles/3/relationships/comments",
+              "related": "/articles/3/comments"
+            },
+            "meta": {
+              "comment-count": 5
+            }
+          }
+        },
+        "links": {
+          "self": "http://Article/3"
+        },
+        "meta": {
+          "reviewers": ["Christian Bernstein"],
+          "reviewer_initials": "C.B."
+        }
+      }],
+      "links": {
+        "self": "//articles"
+      },
+      "meta": {
+        "count": 3
+      },
+      "included": [{
+        "type": "authors",
+        "id": "2",
+        "links": {
+          "self": "http://authors/2"
+        }
+      }, {
+        "type": "editors",
+        "id": "editor:1"
+      }, {
+        "type": "comments",
+        "id": "comment:1",
+        "attributes": {
+          "body": "Ice and Snow"
+        },
+        "links": {
+          "self": "http://comments/comment:1"
+        }
+      }, {
+        "type": "comments",
+        "id": "comment:2",
+        "attributes": {
+          "body": "Red Stripe Skank"
+        },
+        "links": {
+          "self": "http://comments/comment:2"
+        }
+      }, {
+        "type": "authors",
+        "id": "author:1",
+        "links": {
+          "self": "http://authors/author:1"
+        }
+      }, {
+        "type": "comments",
+        "id": "comment:3",
+        "attributes": {
+          "body": "Cool song!"
+        },
+        "links": {
+          "self": "http://comments/comment:3"
+        }
+      }, {
+        "type": "comments",
+        "id": "comment:4",
+        "attributes": {
+          "body": "Skalar"
+        },
+        "links": {
+          "self": "http://comments/comment:4"
+        }
+      }]
+    }))
   end
 
   it "included: false suppresses compound docs" do
-    hash = decorator.to_hash(included: false)
-    hash.must_equal('data'  => [
-                      {
-                        'type'          => 'articles',
-                        'id'            => '1',
-                        'attributes'    => { 'title' => 'Health walk' },
-                        'relationships' => {
-                          'author'   => {
-                            'data'  => { 'type' => 'authors', 'id' => '2' },
-                            'links' => {
-                              'self'    => '/articles/1/relationships/author',
-                              'related' => '/articles/1/author'
-                            }
-                          },
-                          'editor'   => {
-                            'data' => { 'type' => 'editors', 'id' => 'editor:1' },
-                            'meta' => { 'peer_reviewed' => false }
-                          },
-                          'comments' => {
-                            'data'  => [
-                              { 'type' => 'comments', 'id' => 'comment:1' },
-                              { 'type' => 'comments', 'id' => 'comment:2' }
-                            ],
-                            'links' => {
-                              'self'    => '/articles/1/relationships/comments',
-                              'related' => '/articles/1/comments'
-                            },
-                            'meta' => { 'comment-count' => 5 }
-                          }
-                        },
-                        'links'         => { 'self' => 'http://Article/1' },
-                        'meta'          => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
-                      },
-                      {
-                        'type'          => 'articles',
-                        'id'            => '2',
-                        'attributes'    => { 'title' => 'Virgin Ska' },
-                        'relationships' => {
-                          'author'   => {
-                            'data'  => { 'type' => 'authors', 'id' => 'author:1' },
-                            'links' => {
-                              'self'    => '/articles/2/relationships/author',
-                              'related' => '/articles/2/author'
-                            }
-                          },
-                          'editor'   => {
-                            'data' => nil,
-                            'meta' => { 'peer_reviewed' => false }
-                          },
-                          'comments' => {
-                            'data'  => [
-                              { 'type' => 'comments', 'id' => 'comment:3' }
-                            ],
-                            'links' => {
-                              'self'    => '/articles/2/relationships/comments',
-                              'related' => '/articles/2/comments'
-                            },
-                            'meta' => { 'comment-count' => 5 }
-                          }
-                        },
-                        'links'         => { 'self' => 'http://Article/2' },
-                        'meta'          => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
-                      },
-                      {
-                        'type'          => 'articles',
-                        'id'            => '3',
-                        'attributes'    => { 'title' => 'Gramo echo' },
-                        'relationships' => {
-                          'author'   => {
-                            'data'  => { 'type' => 'authors', 'id' => 'author:1' },
-                            'links' => {
-                              'self'    => '/articles/3/relationships/author',
-                              'related' => '/articles/3/author'
-                            }
-                          },
-                          'editor'   => {
-                            'data' => nil,
-                            'meta' => { 'peer_reviewed' => false }
-                          },
-                          'comments' => {
-                            'data'  => [
-                              { 'type' => 'comments', 'id' => 'comment:4' }
-                            ],
-                            'links' => {
-                              'self'    => '/articles/3/relationships/comments',
-                              'related' => '/articles/3/comments'
-                            },
-                            'meta' => { 'comment-count' => 5 }
-                          }
-                        },
-                        'links'         => { 'self' => 'http://Article/3' },
-                        'meta'          => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
-                      }
-                    ],
-                    'links' => { 'self' => '//articles' },
-                    'meta'  => { 'count' => 3 })
+    json = decorator.to_json(included: false)
+    json.must_equal_json(%({
+      "data": [{
+        "type": "articles",
+        "id": "1",
+        "attributes": {
+          "title": "Health walk"
+        },
+        "relationships": {
+          "author": {
+            "data": {
+              "type": "authors",
+              "id": "2"
+            },
+            "links": {
+              "self": "/articles/1/relationships/author",
+              "related": "/articles/1/author"
+            }
+          },
+          "editor": {
+            "data": {
+              "type": "editors",
+              "id": "editor:1"
+            },
+            "meta": {
+              "peer_reviewed": false
+            }
+          },
+          "comments": {
+            "data": [{
+              "type": "comments",
+              "id": "comment:1"
+            }, {
+              "type": "comments",
+              "id": "comment:2"
+            }],
+            "links": {
+              "self": "/articles/1/relationships/comments",
+              "related": "/articles/1/comments"
+            },
+            "meta": {
+              "comment-count": 5
+            }
+          }
+        },
+        "links": {
+          "self": "http://Article/1"
+        },
+        "meta": {
+          "reviewers": ["Christian Bernstein"],
+          "reviewer_initials": "C.B."
+        }
+      }, {
+        "type": "articles",
+        "id": "2",
+        "attributes": {
+          "title": "Virgin Ska"
+        },
+        "relationships": {
+          "author": {
+            "data": {
+              "type": "authors",
+              "id": "author:1"
+            },
+            "links": {
+              "self": "/articles/2/relationships/author",
+              "related": "/articles/2/author"
+            }
+          },
+          "editor": {
+            "data": null,
+            "meta": {
+              "peer_reviewed": false
+            }
+          },
+          "comments": {
+            "data": [{
+              "type": "comments",
+              "id": "comment:3"
+            }],
+            "links": {
+              "self": "/articles/2/relationships/comments",
+              "related": "/articles/2/comments"
+            },
+            "meta": {
+              "comment-count": 5
+            }
+          }
+        },
+        "links": {
+          "self": "http://Article/2"
+        },
+        "meta": {
+          "reviewers": ["Christian Bernstein"],
+          "reviewer_initials": "C.B."
+        }
+      }, {
+        "type": "articles",
+        "id": "3",
+        "attributes": {
+          "title": "Gramo echo"
+        },
+        "relationships": {
+          "author": {
+            "data": {
+              "type": "authors",
+              "id": "author:1"
+            },
+            "links": {
+              "self": "/articles/3/relationships/author",
+              "related": "/articles/3/author"
+            }
+          },
+          "editor": {
+            "data": null,
+            "meta": {
+              "peer_reviewed": false
+            }
+          },
+          "comments": {
+            "data": [{
+              "type": "comments",
+              "id": "comment:4"
+            }],
+            "links": {
+              "self": "/articles/3/relationships/comments",
+              "related": "/articles/3/comments"
+            },
+            "meta": {
+              "comment-count": 5
+            }
+          }
+        },
+        "links": {
+          "self": "http://Article/3"
+        },
+        "meta": {
+          "reviewers": ["Christian Bernstein"],
+          "reviewer_initials": "C.B."
+        }
+      }],
+      "links": {
+        "self": "//articles"
+      },
+      "meta": {
+        "count": 3
+      }
+    }))
   end
 
   it "passes :user_options to toplevel links when rendering" do
@@ -266,20 +382,20 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
 
   describe "Fetching Resources (empty collection)" do
     let(:document) {
-      {
-        "data" => [],
-        "links" => {
-          "self" => "//articles"
+      %({
+        "data": [],
+        "links": {
+          "self": "//articles"
         },
-        "meta" => {
-          "count" => 0
+        "meta": {
+          "count": 0
         }
-      }
+      })
     }
 
     let(:articles) { [] }
     subject { ArticleDecorator.for_collection.new(articles).to_json }
 
-    it { subject.must_equal document.to_json }
+    it { subject.must_equal_json document }
   end
 end

--- a/test/jsonapi/fieldsets_test.rb
+++ b/test/jsonapi/fieldsets_test.rb
@@ -45,56 +45,82 @@ class JSONAPIFieldsetsTest < Minitest::Spec
         to_json(attributes: { include: [:title] },
           included: { include: []},
           relationships: { include: []}).
-        must_equal( {
-          "data" => {
-            "id" => "1",
-            "attributes" => {
-              "title" => "My Article"
-            },
-            "type" => "articles"
+        must_equal_json(%(
+          {
+            "data": {
+              "id": "1",
+              "attributes": {
+                "title": "My Article"
+              },
+              "type": "articles"
+            }
           }
-        }.to_json )
+        ))
     end
 
     it "includes compound objects" do
       DocumentSingleResourceObjectDecorator.new(article).
-        to_hash(
+        to_json(
           attributes: { include:  [:id, :title] },
           included: {include: [:comments]},
           relationships: { include: []}).
-        must_equal Hash[{
-          'data'=>
-            {'type'=>"articles",
-             'id'=>"1",
-             'attributes'=>{"title"=>"My Article"},
+        must_equal_json(%(
+          {
+            "data": {
+              "id": "1",
+              "attributes": {
+                "title": "My Article"
+              },
+              "type": "articles"
             },
-           'included'=>
-            [{'type'=>"comments",
-              'id'=>"c:1",
-              'attributes'=>{"body"=>"Cool!", "good"=>true}},
-             {'type'=>"comments",
-              'id'=>"c:2",
-              'attributes'=>{"body"=>"Nah", "good"=>false}}
+            "included": [
+              {
+                "type": "comments",
+                "id": "c:1",
+                "attributes": {
+                  "body": "Cool!",
+                  "good": true
+                }
+              },
+              {
+                "type": "comments",
+                "id": "c:2",
+                "attributes": {
+                  "body": "Nah",
+                  "good": false
+                }
+              }
             ]
-        }]
-        # must_equal document.to_json
+          }
+        ))
     end
 
     it "includes other compound objects" do
       DocumentSingleResourceObjectDecorator.new(article).
-        to_hash(attributes: { include: [:title] },
+        to_json(attributes: { include: [:title] },
           included: {include: [:author]},
           relationships: { include: []}).
-        must_equal Hash[{
-          'data'=>
-            {'type'=>"articles",
-             'id'=>"1",
-             'attributes'=>{"title"=>"My Article"},
+        must_equal_json(%(
+          {
+            "data": {
+              "id": "1",
+              "attributes": {
+                "title": "My Article"
+              },
+              "type": "articles"
             },
-           'included'=>
-            [{'type'=>"author", 'id'=>"a:1", 'attributes'=>{"name"=>"Celso", "email"=>"celsito@trb.to"}}]
-        }]
-        # must_equal document.to_json
+            "included": [
+              {
+                "type": "author",
+                "id": "a:1",
+                "attributes": {
+                  "email": "celsito@trb.to",
+                  "name": "Celso"
+                }
+              }
+            ]
+          }
+        ))
     end
 
     describe "collection" do
@@ -148,31 +174,31 @@ class JSONAPIFieldsetsTest < Minitest::Spec
     end
 
     let(:document) {
-      {
-        "data" => [
+      %({
+        "data": [
           {
-            "id" => "1",
-            "attributes" => {
-              "title" => "My Article"
+            "id": "1",
+            "attributes": {
+              "title": "My Article"
             },
-            "type" => "articles"
+            "type": "articles"
           },
           {
-            "id" => "2",
-            "attributes" => {
-              "title" => "My Other Article"
+            "id": "2",
+            "attributes": {
+              "title": "My Other Article"
             },
-            "type" => "articles"
+            "type": "articles"
           }
         ]
-      }
+      })
     }
 
     it do
       CollectionResourceObjectDecorator.for_collection.new([
         Article.new(1, "My Article", "An interesting read."),
         Article.new(2, "My Other Article", "An interesting read.")
-      ]).to_json(attributes: { include: [:title] }).must_equal document.to_json
+      ]).to_json(attributes: { include: [:title] }).must_equal_json document
     end
   end
 end

--- a/test/jsonapi/fieldsets_test.rb
+++ b/test/jsonapi/fieldsets_test.rb
@@ -29,7 +29,7 @@ class JSONAPIFieldsetsTest < Minitest::Spec
       end
 
       has_one :author do
-        type :author
+        type :authors
 
         attributes do
           property :name
@@ -112,7 +112,7 @@ class JSONAPIFieldsetsTest < Minitest::Spec
             },
             "included": [
               {
-                "type": "author",
+                "type": "authors",
                 "id": "a:1",
                 "attributes": {
                   "email": "celsito@trb.to",
@@ -137,7 +137,7 @@ class JSONAPIFieldsetsTest < Minitest::Spec
                                                    'attributes' => { 'title'=>'My Article' } }
                                                ],
                                                'included' =>
-                                                             [{ 'type' => 'author', 'id' => 'a:1', 'attributes' => { 'name' => 'Celso', 'email' => 'celsito@trb.to' } }]
+                                                             [{ 'type' => 'authors', 'id' => 'a:1', 'attributes' => { 'name' => 'Celso', 'email' => 'celsito@trb.to' } }]
                                              }]
       end
 

--- a/test/jsonapi/fieldsets_test.rb
+++ b/test/jsonapi/fieldsets_test.rb
@@ -1,15 +1,15 @@
-require "test_helper"
-require "roar/json/json_api"
-require "json"
+require 'test_helper'
+require 'roar/json/json_api'
+require 'json'
 
 class JSONAPIFieldsetsTest < Minitest::Spec
   Article = Struct.new(:id, :title, :summary, :comments, :author)
   Comment = Struct.new(:id, :body, :good)
   Author = Struct.new(:id, :name, :email)
 
-  let (:comments) { [Comment.new("c:1", "Cool!", true), Comment.new("c:2", "Nah", false)] }
+  let(:comments) { [Comment.new('c:1', 'Cool!', true), Comment.new('c:2', 'Nah', false)] }
 
-  describe "Single Resource Object With Options" do
+  describe 'Single Resource Object With Options' do
     class DocumentSingleResourceObjectDecorator < Roar::Decorator
       include Roar::JSON::JSONAPI
       type :articles
@@ -38,14 +38,14 @@ class JSONAPIFieldsetsTest < Minitest::Spec
       end
     end
 
-    let (:article) { Article.new(1, "My Article", "An interesting read.", comments, Author.new("a:1", "Celso", "celsito@trb.to")) }
+    let(:article) { Article.new(1, 'My Article', 'An interesting read.', comments, Author.new('a:1', 'Celso', 'celsito@trb.to')) }
 
-    it "includes scalars" do
-      DocumentSingleResourceObjectDecorator.new(article).
-        to_json(attributes: { include: [:title] },
-          included: { include: []},
-          relationships: { include: []}).
-        must_equal_json(%(
+    it 'includes scalars' do
+      DocumentSingleResourceObjectDecorator.new(article)
+                                           .to_json(attributes:    { include: [:title] },
+                                                    included:      { include: [] },
+                                                    relationships: { include: [] })
+                                           .must_equal_json(%(
           {
             "data": {
               "id": "1",
@@ -58,13 +58,14 @@ class JSONAPIFieldsetsTest < Minitest::Spec
         ))
     end
 
-    it "includes compound objects" do
-      DocumentSingleResourceObjectDecorator.new(article).
-        to_json(
-          attributes: { include:  [:id, :title] },
-          included: {include: [:comments]},
-          relationships: { include: []}).
-        must_equal_json(%(
+    it 'includes compound objects' do
+      DocumentSingleResourceObjectDecorator.new(article)
+                                           .to_json(
+                                             attributes:    { include: [:id, :title] },
+                                             included:      { include: [:comments] },
+                                             relationships: { include: [] }
+                                           )
+                                           .must_equal_json(%(
           {
             "data": {
               "id": "1",
@@ -95,12 +96,12 @@ class JSONAPIFieldsetsTest < Minitest::Spec
         ))
     end
 
-    it "includes other compound objects" do
-      DocumentSingleResourceObjectDecorator.new(article).
-        to_json(attributes: { include: [:title] },
-          included: {include: [:author]},
-          relationships: { include: []}).
-        must_equal_json(%(
+    it 'includes other compound objects' do
+      DocumentSingleResourceObjectDecorator.new(article)
+                                           .to_json(attributes:    { include: [:title] },
+                                                    included:      { include: [:author] },
+                                                    relationships: { include: [] })
+                                           .must_equal_json(%(
           {
             "data": {
               "id": "1",
@@ -123,46 +124,46 @@ class JSONAPIFieldsetsTest < Minitest::Spec
         ))
     end
 
-    describe "collection" do
-      it "supports :includes" do
-        DocumentSingleResourceObjectDecorator.for_collection.new([article]).
-          to_hash(attributes: { include: [:title] },
-            included: {include: [:author]},
-            relationships: { include: []}).
-          must_equal Hash[{
-            'data'=>[
-              {'type'=>"articles",
-               'id'=>"1",
-               'attributes'=>{"title"=>"My Article"},
-              }],
-            'included'=>
-              [{'type'=>"author", 'id'=>"a:1", 'attributes'=>{"name"=>"Celso", "email"=>"celsito@trb.to"}}]
-          }]
+    describe 'collection' do
+      it 'supports :includes' do
+        DocumentSingleResourceObjectDecorator.for_collection.new([article])
+                                             .to_hash(attributes:    { include: [:title] },
+                                                      included:      { include: [:author] },
+                                                      relationships: { include: [] })
+                                             .must_equal Hash[{
+                                               'data'     => [
+                                                 { 'type'       => 'articles',
+                                                   'id'         => '1',
+                                                   'attributes' => { 'title'=>'My Article' } }
+                                               ],
+                                               'included' =>
+                                                             [{ 'type' => 'author', 'id' => 'a:1', 'attributes' => { 'name' => 'Celso', 'email' => 'celsito@trb.to' } }]
+                                             }]
       end
 
       # include: ROAR API
-      it "blaaaaaaa" do
+      it 'blaaaaaaa' do
         skip 'rework included API'
-        DocumentSingleResourceObjectDecorator.for_collection.new([article]).
-          to_hash(
-            attributes: { include: [:title ] },
-            included: { include: { author: [:email]}},
-            relationships: { include: [] }
-          ).
-          must_equal Hash[{
-            'data'=>[
-              {'type'=>"articles",
-               'id'=>"1",
-               'attributes'=>{"title"=>"My Article"},
-              }],
-            'included'=>
-              [{'type'=>"author", 'id'=>"a:1", 'attributes'=>{"email"=>"celsito@trb.to"}}]
-          }]
+        DocumentSingleResourceObjectDecorator.for_collection.new([article])
+                                             .to_hash(
+                                               attributes:    { include: [:title] },
+                                               included:      { include: { author: [:email] } },
+                                               relationships: { include: [] }
+                                             )
+                                             .must_equal Hash[{
+                                               'data'     => [
+                                                 { 'type'       => 'articles',
+                                                   'id'         => '1',
+                                                   'attributes' => { 'title'=>'My Article' } }
+                                               ],
+                                               'included' =>
+                                                             [{ 'type' => 'author', 'id' => 'a:1', 'attributes' => { 'email'=>'celsito@trb.to' } }]
+                                             }]
       end
     end
   end
 
-  describe "Collection Resources With Options" do
+  describe 'Collection Resources With Options' do
     class CollectionResourceObjectDecorator < Roar::Decorator
       include Roar::JSON::JSONAPI
       type :articles
@@ -196,9 +197,9 @@ class JSONAPIFieldsetsTest < Minitest::Spec
 
     it do
       CollectionResourceObjectDecorator.for_collection.new([
-        Article.new(1, "My Article", "An interesting read."),
-        Article.new(2, "My Other Article", "An interesting read.")
-      ]).to_json(attributes: { include: [:title] }).must_equal_json document
+                                                             Article.new(1, 'My Article', 'An interesting read.'),
+                                                             Article.new(2, 'My Other Article', 'An interesting read.')
+                                                           ]).to_json(attributes: { include: [:title] }).must_equal_json document
     end
   end
 end

--- a/test/jsonapi/post_test.rb
+++ b/test/jsonapi/post_test.rb
@@ -5,30 +5,35 @@ require "json"
 class JsonapiPostTest < MiniTest::Spec
   describe "Parse" do
     let(:post_article) {
-      {
-        "data" => {
-          "type" => "articles",
-          "attributes" => {
-            "title" => "Ember Hamster",
+      %({
+        "data": {
+          "type": "articles",
+          "attributes": {
+            "title": "Ember Hamster"
           },
-          # that does do `photo.photographer= Photographer.find(9)`
-          "relationships" => {
-            "author" => {
-              "data" => { "type" => "people", "id" => "9", "name" => "Celsito" } # FIXME: what should happen if i add `"name" => "Celsito"` here? should that be read or not?
+          "relationships": {
+            "author": {
+              "data": {
+                "type": "people",
+                "id": "9",
+                "name": "Celsito"
+              }
             },
-            "comments" => {
-              "data" => [
-                { "type" => "comment", "id" => "2" },
-                { "type" => "comment", "id" => "3" },
-              ]
+            "comments": {
+              "data": [{
+                "type": "comment",
+                "id": "2"
+              }, {
+                "type": "comment",
+                "id": "3"
+              }]
             }
-
           }
         }
-      }
+      })
     }
 
-    subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article.to_json) }
+    subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article) }
 
     it do
       subject.title.must_equal "Ember Hamster"
@@ -42,17 +47,17 @@ class JsonapiPostTest < MiniTest::Spec
 
   describe "Parse Simple" do
     let(:post_article) {
-      {
-        "data" => {
-          "type" => "articles",
-          "attributes" => {
-            "title" => "Ember Hamster",
+      %({
+        "data": {
+          "type": "articles",
+          "attributes": {
+            "title": "Ember Hamster"
           }
         }
-      }
+      })
     }
 
-    subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article.to_json) }
+    subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article) }
 
     it do
       subject.title.must_equal "Ember Hamster"
@@ -61,10 +66,10 @@ class JsonapiPostTest < MiniTest::Spec
 
   describe "Parse Badly Formed Document" do
     let(:post_article) {
-      { "title" => "Ember Hamster" }
+      %({"title":"Ember Hamster"})
     }
 
-    subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article.to_json) }
+    subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article) }
 
     it do
       subject.title.must_be_nil

--- a/test/jsonapi/post_test.rb
+++ b/test/jsonapi/post_test.rb
@@ -1,9 +1,9 @@
-require "test_helper"
-require "roar/json/json_api"
-require "json"
+require 'test_helper'
+require 'roar/json/json_api'
+require 'json'
 
 class JsonapiPostTest < MiniTest::Spec
-  describe "Parse" do
+  describe 'Parse' do
     let(:post_article) {
       %({
         "data": {
@@ -36,16 +36,16 @@ class JsonapiPostTest < MiniTest::Spec
     subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article) }
 
     it do
-      subject.title.must_equal "Ember Hamster"
-      subject.author.id.must_equal "9"
-      subject.author.email.must_equal "9@nine.to"
+      subject.title.must_equal 'Ember Hamster'
+      subject.author.id.must_equal '9'
+      subject.author.email.must_equal '9@nine.to'
       # subject.author.name.must_be_nil
 
-      subject.comments.must_equal [Comment.new("2"), Comment.new("3")]
+      subject.comments.must_equal [Comment.new('2'), Comment.new('3')]
     end
   end
 
-  describe "Parse Simple" do
+  describe 'Parse Simple' do
     let(:post_article) {
       %({
         "data": {
@@ -60,11 +60,11 @@ class JsonapiPostTest < MiniTest::Spec
     subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article) }
 
     it do
-      subject.title.must_equal "Ember Hamster"
+      subject.title.must_equal 'Ember Hamster'
     end
   end
 
-  describe "Parse Badly Formed Document" do
+  describe 'Parse Badly Formed Document' do
     let(:post_article) {
       %({"title":"Ember Hamster"})
     }

--- a/test/jsonapi/post_test.rb
+++ b/test/jsonapi/post_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 require "roar/json/json_api"
 require "json"
-require "jsonapi/representer"
 
 class JsonapiPostTest < MiniTest::Spec
   describe "Parse" do

--- a/test/jsonapi/render_test.rb
+++ b/test/jsonapi/render_test.rb
@@ -7,99 +7,145 @@ class JsonapiRenderTest < MiniTest::Spec
   let (:decorator) { ArticleDecorator.new(article) }
 
   it "renders full document" do
-    hash = decorator.to_hash
-    hash.must_equal(
-      'data'     => {
-        'type'          => 'articles',
-        'id'            => '1',
-        'attributes'    => { 'title' => 'Health walk' },
-        'relationships' => {
-          'author'   => {
-            'data'  => { 'type' => 'authors', 'id' => '2' },
-            'links' => {
-              'self'    => '/articles/1/relationships/author',
-              'related' => '/articles/1/author'
+    json = decorator.to_json
+    json.must_equal_json(%({
+      "data": {
+        "id": "1",
+        "relationships": {
+          "author": {
+            "data": {
+              "id": "2",
+              "type": "authors"
+            },
+            "links": {
+              "self": "/articles/1/relationships/author",
+              "related": "/articles/1/author"
             }
           },
-          'editor'   => {
-            'data' => { 'type' => 'editors', 'id' => 'editor:1' },
-            'meta' => { 'peer_reviewed' => false }
-          },
-          'comments' => {
-            'data'  => [
-              { 'type' => 'comments', 'id' => 'comment:1' },
-              { 'type' => 'comments', 'id' => 'comment:2' }
-            ],
-            'links' => {
-              'self'    => '/articles/1/relationships/comments',
-              'related' => '/articles/1/comments'
+          "editor": {
+            "data": {
+              "id": "editor:1",
+              "type": "editors"
             },
-            'meta'  => { 'comment-count' => 5 }
+            "meta": {
+              "peer_reviewed": false
+            }
+          },
+          "comments": {
+            "data": [{
+              "id": "comment:1",
+              "type": "comments"
+            }, {
+              "id": "comment:2",
+              "type": "comments"
+            }],
+            "links": {
+              "self": "/articles/1/relationships/comments",
+              "related": "/articles/1/comments"
+            },
+            "meta": {
+              "comment-count": 5
+            }
           }
         },
-        'links'         => { 'self' => 'http://Article/1' }
-      },
-      'included' => [
-        {
-          'type'  => 'authors',
-          'id'    => '2',
-          'links' => { 'self' => 'http://authors/2' }
+        "attributes": {
+          "title": "Health walk"
         },
-        {
-          'type' => 'editors',
-          'id'   => 'editor:1'
-        },
-        {
-          'type'       => 'comments',
-          'id'         => 'comment:1',
-          'attributes' => { 'body' => 'Ice and Snow' },
-          'links'      => { 'self' => 'http://comments/comment:1' }
-        },
-        {
-          'type'       => 'comments',
-          'id'         => 'comment:2',
-          'attributes' => { 'body' => 'Red Stripe Skank' },
-          'links'      => { 'self' => 'http://comments/comment:2' }
+        "type": "articles",
+        "links": {
+          "self": "http://Article/1"
         }
-      ],
-      'meta'     => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
-    )
+      },
+      "included": [{
+        "id": "2",
+        "type": "authors",
+        "links": {
+          "self": "http://authors/2"
+        }
+      }, {
+        "id": "editor:1",
+        "type": "editors"
+      }, {
+        "id": "comment:1",
+        "attributes": {
+          "body": "Ice and Snow"
+        },
+        "type": "comments",
+        "links": {
+          "self": "http://comments/comment:1"
+        }
+      }, {
+        "id": "comment:2",
+        "attributes": {
+          "body": "Red Stripe Skank"
+        },
+        "type": "comments",
+        "links": {
+          "self": "http://comments/comment:2"
+        }
+      }],
+      "meta": {
+        "reviewers": ["Christian Bernstein"],
+        "reviewer_initials": "C.B."
+      }
+    }))
   end
 
   it "included: false suppresses compound docs" do
-    decorator.to_hash(included: false).must_equal(
-      'data' => {
-        'type'          => 'articles',
-        'id'            => '1',
-        'attributes'    => { 'title' => 'Health walk' },
-        'relationships' => {
-          'author'   => {
-            'data'  => { 'type' => 'authors', 'id' => '2' },
-            'links' => {
-              'self'    => '/articles/1/relationships/author',
-              'related' => '/articles/1/author'
+    json = decorator.to_json(included: false)
+    json.must_equal_json(%({
+      "data": {
+        "id": "1",
+        "relationships": {
+          "author": {
+            "data": {
+              "id": "2",
+              "type": "authors"
+            },
+            "links": {
+              "self": "/articles/1/relationships/author",
+              "related": "/articles/1/author"
             }
           },
-          'editor'   => {
-            'data' => { 'type' => 'editors', 'id' => 'editor:1' },
-            'meta' => { 'peer_reviewed' => false }
-          },
-          'comments' => {
-            'data'  => [
-              { 'type' => 'comments', 'id' => 'comment:1' },
-              { 'type' => 'comments', 'id' => 'comment:2' }
-            ],
-            'links' => {
-              'self'    => '/articles/1/relationships/comments',
-              'related' => '/articles/1/comments'
+          "editor": {
+            "data": {
+              "id": "editor:1",
+              "type": "editors"
             },
-            'meta'  => { 'comment-count' => 5 }
+            "meta": {
+              "peer_reviewed": false
+            }
+          },
+          "comments": {
+            "data": [{
+              "id": "comment:1",
+              "type": "comments"
+            }, {
+              "id": "comment:2",
+              "type": "comments"
+            }],
+            "links": {
+              "self": "/articles/1/relationships/comments",
+              "related": "/articles/1/comments"
+            },
+            "meta": {
+              "comment-count": 5
+            }
           }
         },
-        'links'         => { 'self' => 'http://Article/1' }
+        "attributes": {
+          "title": "Health walk"
+        },
+        "type": "articles",
+        "links": {
+          "self": "http://Article/1"
+        }
       },
-      'meta' => { 'reviewers' => ['Christian Bernstein'], 'reviewer_initials' => 'C.B.' }
-    )
+      "meta": {
+        "reviewers": ["Christian Bernstein"],
+        "reviewer_initials": "C.B."
+      }
+    }))
   end
 
   it 'renders additional meta information if meta option supplied' do
@@ -129,20 +175,32 @@ class JsonapiRenderTest < MiniTest::Spec
     end
 
     let(:document) {
-      {
-        "data" => {
-          "id" => "1",
-          "attributes" => {
-            "title" => "My Article"
+      %({
+        "data": {
+          "id": "1",
+          "attributes": {
+            "title": "My Article"
           },
-          "type" => "articles"
+          "type": "articles"
         }
-      }
+      })
     }
 
-    let (:collection_document) { {'data'=>[{'type'=>"articles", 'id'=>"1", 'attributes'=>{"title"=>"My Article"}}]} }
+    let(:collection_document) {
+      %({
+        "data": [
+          {
+            "type": "articles",
+            "id": "1",
+            "attributes": {
+              "title": "My Article"
+            }
+          }
+        ]
+      })
+    }
 
-    it { DocumentSingleResourceObjectDecorator.new(Article.new(1, 'My Article')).to_json.must_equal document.to_json }
-    it { DocumentSingleResourceObjectDecorator.for_collection.new([Article.new(1, 'My Article')]).to_hash.must_equal collection_document }
+    it { DocumentSingleResourceObjectDecorator.new(Article.new(1, 'My Article')).to_json.must_equal_json document }
+    it { DocumentSingleResourceObjectDecorator.for_collection.new([Article.new(1, 'My Article')]).to_json.must_equal_json collection_document }
   end
 end

--- a/test/jsonapi/render_test.rb
+++ b/test/jsonapi/render_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 require "roar/json/json_api"
 require "json"
-require "jsonapi/representer"
 
 class JsonapiRenderTest < MiniTest::Spec
   let (:article) { Article.new(1, "Health walk", Author.new(2), Author.new("editor:1"), [Comment.new("comment:1", "Ice and Snow"),Comment.new("comment:2", "Red Stripe Skank")]) }
@@ -124,18 +123,19 @@ class JsonapiRenderTest < MiniTest::Spec
       include Roar::JSON::JSONAPI
       type :articles
 
-      property :id
-      property :title
+      attributes do
+        property :title
+      end
     end
 
     let(:document) {
       {
         "data" => {
-          "type" => "articles",
           "id" => "1",
           "attributes" => {
             "title" => "My Article"
-          }
+          },
+          "type" => "articles"
         }
       }
     }

--- a/test/jsonapi/render_test.rb
+++ b/test/jsonapi/render_test.rb
@@ -1,12 +1,12 @@
-require "test_helper"
-require "roar/json/json_api"
-require "json"
+require 'test_helper'
+require 'roar/json/json_api'
+require 'json'
 
 class JsonapiRenderTest < MiniTest::Spec
-  let (:article) { Article.new(1, "Health walk", Author.new(2), Author.new("editor:1"), [Comment.new("comment:1", "Ice and Snow"),Comment.new("comment:2", "Red Stripe Skank")]) }
-  let (:decorator) { ArticleDecorator.new(article) }
+  let(:article) { Article.new(1, 'Health walk', Author.new(2), Author.new('editor:1'), [Comment.new('comment:1', 'Ice and Snow'), Comment.new('comment:2', 'Red Stripe Skank')]) }
+  let(:decorator) { ArticleDecorator.new(article) }
 
-  it "renders full document" do
+  it 'renders full document' do
     json = decorator.to_json
     json.must_equal_json(%({
       "data": {
@@ -91,7 +91,7 @@ class JsonapiRenderTest < MiniTest::Spec
     }))
   end
 
-  it "included: false suppresses compound docs" do
+  it 'included: false suppresses compound docs' do
     json = decorator.to_json(included: false)
     json.must_equal_json(%({
       "data": {
@@ -150,8 +150,8 @@ class JsonapiRenderTest < MiniTest::Spec
 
   it 'renders additional meta information if meta option supplied' do
     hash = decorator.to_hash('meta' => {
-      'copyright' => 'Nick Sutterer', 'reviewers' => []
-    })
+                               'copyright' => 'Nick Sutterer', 'reviewers' => []
+                             })
     hash['meta']['copyright'].must_equal('Nick Sutterer')
     hash['meta']['reviewers'].must_equal([])
     hash['meta']['reviewer_initials'].must_equal('C.B.')
@@ -164,7 +164,7 @@ class JsonapiRenderTest < MiniTest::Spec
     hash['meta']['reviewer_initials'].must_equal('C.B.')
   end
 
-  describe "Single Resource Object" do
+  describe 'Single Resource Object' do
     class DocumentSingleResourceObjectDecorator < Roar::Decorator
       include Roar::JSON::JSONAPI
       type :articles

--- a/test/jsonapi/representer.rb
+++ b/test/jsonapi/representer.rb
@@ -17,6 +17,42 @@ Comment = Struct.new(:id, :body) do
   end
 end
 
+class AuthorDecorator < Roar::Decorator
+  include Roar::JSON::JSONAPI
+  type :authors
+
+  relationship do
+    link(:self)     { "/articles/#{represented.id}/relationships/author" }
+    link(:related)  { "/articles/#{represented.id}/author" }
+  end
+
+  attributes do
+    property :email
+  end
+
+  link(:self) { "http://authors/#{represented.id}" }
+end
+
+class CommentDecorator < Roar::Decorator
+  include Roar::JSON::JSONAPI
+  type :comments
+
+  relationship do
+    link(:self)     { "/articles/#{represented.id}/relationships/comments" }
+    link(:related)  { "/articles/#{represented.id}/comments" }
+
+    meta do
+      property :count, as: 'comment-count'
+    end
+  end
+
+  attributes do
+    property :body
+  end
+
+  link(:self) { "http://comments/#{represented.id}" }
+end
+
 class ArticleDecorator < Roar::Decorator
   include Roar::JSON::JSONAPI
   type :articles
@@ -34,9 +70,9 @@ class ArticleDecorator < Roar::Decorator
     property :count
   end
 
-  # attributes: {}
-  property :id
-  property :title
+  attributes do
+    property :title
+  end
 
   meta do
     collection :reviewers
@@ -54,18 +90,8 @@ class ArticleDecorator < Roar::Decorator
   link(:self) { "http://#{represented.class}/#{represented.id}" }
 
   # relationships
-  has_one :author, class: Author, populator: ::Representable::FindOrInstantiate do # populator is for parsing, only.
-    type :authors
-
-    relationship do
-      link(:self)     { "/articles/#{represented.id}/relationships/author" }
-      link(:related)  { "/articles/#{represented.id}/author" }
-    end
-
-    property :id
-    property :email
-    link(:self) { "http://authors/#{represented.id}" }
-  end
+  has_one :author, class: Author, decorator: AuthorDecorator,
+    populator: ::Representable::FindOrInstantiate # populator is for parsing, only.
 
   has_one :editor do
     type :editors
@@ -76,25 +102,12 @@ class ArticleDecorator < Roar::Decorator
       end
     end
 
-    property :id
-    property :email
+    attributes do
+      property :email
+    end
     # No self link for editors because we want to make sure the :links option does not appear in the hash.
   end
 
-  has_many :comments, class: Comment, populator: ::Representable::FindOrInstantiate do
-    type :comments
-
-    relationship do
-      link(:self)     { "/articles/#{represented.id}/relationships/comments" }
-      link(:related)  { "/articles/#{represented.id}/comments" }
-
-      meta do
-        property :count, as: 'comment-count'
-      end
-    end
-
-    property :id
-    property :body
-    link(:self) { "http://comments/#{represented.id}" }
-  end
+  has_many :comments, class: Comment, decorator: CommentDecorator,
+    populator: ::Representable::FindOrInstantiate
 end

--- a/test/jsonapi/representer.rb
+++ b/test/jsonapi/representer.rb
@@ -1,9 +1,9 @@
 Author = Struct.new(:id, :email, :name) do
   def self.find_by(options)
-    AuthorNine if options[:id].to_s=="9"
+    AuthorNine if options[:id].to_s == '9'
   end
 end
-AuthorNine = Author.new(9, "9@nine.to")
+AuthorNine = Author.new(9, '9@nine.to')
 
 Article = Struct.new(:id, :title, :author, :editor, :comments) do
   def reviewers
@@ -12,7 +12,7 @@ Article = Struct.new(:id, :title, :author, :editor, :comments) do
 end
 
 Comment = Struct.new(:id, :body) do
-  def self.find_by(options)
+  def self.find_by(_options)
     new
   end
 end
@@ -48,7 +48,7 @@ class ArticleDecorator < Roar::Decorator
     if options
       "//articles?page=#{options[:page]}&per_page=#{options[:per_page]}"
     else
-      "//articles"
+      '//articles'
     end
   end
 
@@ -66,7 +66,7 @@ class ArticleDecorator < Roar::Decorator
 
   meta do
     property :reviewer_initials, getter: ->(_) {
-      reviewers.map {|reviewer|
+      reviewers.map { |reviewer|
         reviewer.split.map { |name| "#{name[0]}." }.join
       }.join(', ')
     }

--- a/test/jsonapi/representer.rb
+++ b/test/jsonapi/representer.rb
@@ -21,11 +21,6 @@ class AuthorDecorator < Roar::Decorator
   include Roar::JSON::JSONAPI
   type :authors
 
-  relationship do
-    link(:self)     { "/articles/#{represented.id}/relationships/author" }
-    link(:related)  { "/articles/#{represented.id}/author" }
-  end
-
   attributes do
     property :email
   end
@@ -36,15 +31,6 @@ end
 class CommentDecorator < Roar::Decorator
   include Roar::JSON::JSONAPI
   type :comments
-
-  relationship do
-    link(:self)     { "/articles/#{represented.id}/relationships/comments" }
-    link(:related)  { "/articles/#{represented.id}/comments" }
-
-    meta do
-      property :count, as: 'comment-count'
-    end
-  end
 
   attributes do
     property :body
@@ -91,7 +77,13 @@ class ArticleDecorator < Roar::Decorator
 
   # relationships
   has_one :author, class: Author, decorator: AuthorDecorator,
-    populator: ::Representable::FindOrInstantiate # populator is for parsing, only.
+    populator: ::Representable::FindOrInstantiate do # populator is for parsing, only.
+
+    relationship do
+      link(:self)     { "/articles/#{represented.id}/relationships/author" }
+      link(:related)  { "/articles/#{represented.id}/author" }
+    end
+  end
 
   has_one :editor do
     type :editors
@@ -109,5 +101,15 @@ class ArticleDecorator < Roar::Decorator
   end
 
   has_many :comments, class: Comment, decorator: CommentDecorator,
-    populator: ::Representable::FindOrInstantiate
+    populator: ::Representable::FindOrInstantiate do
+
+    relationship do
+      link(:self)     { "/articles/#{represented.id}/relationships/comments" }
+      link(:related)  { "/articles/#{represented.id}/comments" }
+
+      meta do
+        property :count, as: 'comment-count'
+      end
+    end
+  end
 end

--- a/test/jsonapi/resource_linkage_test.rb
+++ b/test/jsonapi/resource_linkage_test.rb
@@ -3,28 +3,30 @@
 require 'test_helper'
 require 'roar/json/json_api'
 require 'json'
-require 'jsonapi/representer'
 
 class ResourceLinkageTest < MiniTest::Spec
   class RecipeDecorator < Roar::Decorator
     include Roar::JSON::JSONAPI
     type :recipes
 
-    property :id
-    property :name
+    attributes do
+      property :name
+    end
 
     has_one :chef do
       type :chefs
 
-      property :id
-      property :name
+      attributes do
+        property :name
+      end
     end
 
     has_many :ingredients do
       type :ingredients
 
-      property :id
-      property :name
+      attributes do
+        property :name
+      end
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,3 +10,33 @@ require 'representable/debug'
 require 'pp'
 
 require_relative 'jsonapi/representer'
+
+require 'json_spec/configuration'
+require 'json_spec/helpers'
+require 'json_spec/exclusion'
+
+if system('colordiff', __FILE__, __FILE__)
+  MiniTest::Assertions.diff = 'colordiff -u'
+end
+
+module JsonSpec
+  extend Configuration
+
+  self.excluded_keys = []
+end
+module MiniTest::Assertions
+  def assert_equal_json(actual, expected)
+    assert_equal scrub(actual), scrub(expected)
+  end
+
+  def scrub(json, path = nil)
+    JsonSpec::Helpers.generate_normalized_json(
+      JsonSpec::Exclusion.exclude_keys(
+        JsonSpec::Helpers.parse_json(json, path)
+      )
+    ).chomp + "\n"
+  end
+end
+module Minitest::Expectations
+  infect_an_assertion :assert_equal_json, :must_equal_json
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,3 +8,5 @@ require 'roar/json/json_api'
 
 require 'representable/debug'
 require 'pp'
+
+require_relative 'jsonapi/representer'


### PR DESCRIPTION
This refactoring attempts to make better use of existing Represntable
idioms, such as `representation_wrap`.

API changes:
* `id` property is automatically defined for a resource.
* resource attributes should be specified in `attributes` block.
* `has_one` and `has_many` now support `decorates:` option (in other
  words, no longer confined to Inline Representers)

Closes #11
