### PR TITLE
Ensure meta: option only renders at top-level

### DIFF
--- a/lib/roar/json/json_api/document.rb
+++ b/lib/roar/json/json_api/document.rb
@@ -43,7 +43,7 @@ module Roar
         # @option options [Hash{Symbol=>[Array<String>]}] fields
         #   fields to returned on a per-type basis.
         # @option options [Hash{#to_s}=>Object] meta
-        #   additional meta information to be rendered in the document.
+        #   extra toplevel meta information to be rendered in the document.
         # @option options [Hash{Symbol=>Symbol}] user_options
         #   additional arbitary options to be passed to the Representer.
         #

--- a/lib/roar/json/json_api/resource_collection.rb
+++ b/lib/roar/json/json_api/resource_collection.rb
@@ -7,7 +7,8 @@ module Roar
       module ResourceCollection
         # @see Document#to_hash
         def to_hash(options = {})
-          document = super(to_a: options, user_options: options[:user_options]) # [{data: {..}, data: {..}}]
+          single_options  = options.reject { |key, _| [:meta, :user_options].include?(key) }
+          document        = super(to_a: single_options, user_options: options[:user_options]) # [{data: {..}, data: {..}}]
 
           links = Renderer::Links.new.(document, options)
           meta  = render_meta(options)

--- a/test/jsonapi/collection_render_test.rb
+++ b/test/jsonapi/collection_render_test.rb
@@ -367,12 +367,18 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
     hash['links'].must_equal('self' => '//articles?page=2&per_page=10')
   end
 
-  it 'renders additional meta information if meta option supplied' do
+  it 'renders extra toplevel meta information if meta option supplied' do
     hash = decorator.to_hash(meta: { page: 2, total: 9 })
     hash['meta'].must_equal('count' => 3, page: 2, total: 9)
   end
 
-  it 'does not render additional meta information if meta option is empty' do
+  it 'does not render extra meta information on resource objects' do
+    hash = decorator.to_hash(meta: { page: 2, total: 9 })
+    refute hash['data'].first['meta'].key?(:page)
+    refute hash['data'].first['meta'].key?(:total)
+  end
+
+  it 'does not render extra toplevel meta information if meta option is empty' do
     hash = decorator.to_hash(meta: {})
     hash['meta'][:page].must_be_nil
     hash['meta'][:total].must_be_nil

--- a/test/jsonapi/render_test.rb
+++ b/test/jsonapi/render_test.rb
@@ -148,7 +148,7 @@ class JsonapiRenderTest < MiniTest::Spec
     }))
   end
 
-  it 'renders additional meta information if meta option supplied' do
+  it 'renders extra toplevel meta information if meta option supplied' do
     hash = decorator.to_hash(meta: {
                                'copyright' => 'Nick Sutterer', 'reviewers' => []
                              })
@@ -157,7 +157,7 @@ class JsonapiRenderTest < MiniTest::Spec
     hash['meta']['reviewer-initials'].must_equal('C.B.')
   end
 
-  it 'does not render additonal meta information if meta option is empty' do
+  it 'does not render extra toplevel meta information if meta option is empty' do
     hash = decorator.to_hash(meta: {})
     hash['meta']['copyright'].must_be_nil
     hash['meta']['reviewers'].must_equal(['Christian Bernstein'])


### PR DESCRIPTION
Top-level meta information should not be rendered on individual resource objects in the primary data array.

Also tighten up wording in tests and documentation.

Closes #23