### PR TITLE
[WIP] Fix performance issue when decorator files are loaded multiple times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 cache: bundler
+script: bundle exec rake default bench
 rvm:
   - 1.9.3
   - 2.1

--- a/Rakefile
+++ b/Rakefile
@@ -10,3 +10,9 @@ Rake::TestTask.new(:test) do |test|
   test.test_files = FileList['test/**/*_test.rb']
   test.verbose = true
 end
+
+Rake::TestTask.new(:bench) do |test|
+  test.libs << 'test'
+  test.test_files = FileList['test/**/*_benchmark.rb']
+  test.verbose = true
+end

--- a/test/jsonapi/render_benchmark.rb
+++ b/test/jsonapi/render_benchmark.rb
@@ -8,6 +8,17 @@ class JsonapiRenderBenchmark < MiniTest::Benchmark
     bench_linear(2, 8, 2)
   end
 
+  def bench_control
+    assert_performance_constant do |n|
+      n.times do |i|
+        # simulates Rails auto-reloading
+        load File.join($SAMPLES_PATH, 'simple_single_resource_object_decorator.rb')
+      end
+
+      SimpleSingleResourceObjectDecorator.new(Article.new(1, 'My Article')).to_json
+    end
+  end
+
   def bench_render
     assert_performance_constant do |n|
       n.times do |i|

--- a/test/jsonapi/render_benchmark.rb
+++ b/test/jsonapi/render_benchmark.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'minitest/benchmark'
+
+$SAMPLES_PATH = File.expand_path('../../samples', __FILE__)
+
+class JsonapiRenderBenchmark < MiniTest::Benchmark
+  def self.bench_range
+    bench_linear(2, 8, 2)
+  end
+
+  def bench_render
+    assert_performance_constant do |n|
+      n.times do |i|
+        # simulates Rails auto-reloading
+        load File.join($SAMPLES_PATH, 'document_single_resource_object_decorator.rb')
+      end
+
+      DocumentSingleResourceObjectDecorator.new(Article.new(1, 'My Article')).to_json
+    end
+  end
+end

--- a/test/samples/document_single_resource_object_decorator.rb
+++ b/test/samples/document_single_resource_object_decorator.rb
@@ -1,0 +1,7 @@
+class DocumentSingleResourceObjectDecorator < Roar::Decorator
+  include Roar::JSON::JSONAPI.resource :articles
+
+  attributes do
+    property :title
+  end
+end

--- a/test/samples/simple_single_resource_object_decorator.rb
+++ b/test/samples/simple_single_resource_object_decorator.rb
@@ -1,0 +1,5 @@
+class SimpleSingleResourceObjectDecorator < Representable::Decorator
+  include Representable::JSON
+
+  property :title
+end

--- a/test/samples/simple_single_resource_object_decorator.rb
+++ b/test/samples/simple_single_resource_object_decorator.rb
@@ -1,5 +1,5 @@
-class SimpleSingleResourceObjectDecorator < Representable::Decorator
-  include Representable::JSON
+class SimpleSingleResourceObjectDecorator < Roar::Decorator
+  include Roar::JSON
 
   property :title
 end


### PR DESCRIPTION
NOTE: This is a work-in-progress.

Fixes #28

Here is a proof-of-concept here that shows the slowdown:

https://github.com/luma-institute/roar-jsonapi-test

In our case, we use `trailblazer` and `roar-jsonapi` within Rails, and the performance slowdown showed up in our development environment. We were able to reproduce the problem without Rails being involved, both in the linked repo and with a minimal benchmark test case in this PR.

Failing test written first. Goal is to come up with a minimal fix to be applied to this repo to make the test pass and thus remove the slowdown.