### PR TITLE
has_one and has_many declarations now consider the option[:as]

### DIFF
--- a/lib/roar/json/json_api/declarative.rb
+++ b/lib/roar/json/json_api/declarative.rb
@@ -157,7 +157,7 @@ module Roar
           end
 
           nested(:relationships, inherit: true) do
-            nested(:"#{name}_relationship", as: MemberName.(name)) do
+            nested(:"#{name}_relationship", as: options[:as] || MemberName.(name)) do
               property name, options.merge(as:           :data,
                                            getter:       ->(opts) {
                                              object = opts[:binding].send(:exec_context, opts)

--- a/test/jsonapi/resource_custom_naming_test.rb
+++ b/test/jsonapi/resource_custom_naming_test.rb
@@ -1,0 +1,59 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'roar/json/json_api'
+require 'json'
+
+class ResourceCustomNameTest < MiniTest::Spec
+  class ChefDecorator < Roar::Decorator
+    include Roar::JSON::JSONAPI.resource :chefs
+
+    attributes do
+      property :name
+    end
+  end
+
+  class IngredientDecorator < Roar::Decorator
+    include Roar::JSON::JSONAPI.resource :ingredients
+
+    attributes do
+      property :name
+    end
+  end
+
+  class RecipeDecorator < Roar::Decorator
+    include Roar::JSON::JSONAPI.resource :recipes
+
+    attributes do
+      property :name
+    end
+
+    has_one   :best_chef,        as: "bestChefEver", extend: ChefDecorator
+    has_many  :best_ingredients, as: "bestIngridients", extend: IngredientDecorator
+  end
+
+  Recipe      = Struct.new(:id, :name, :best_chef, :best_ingredients, :reviews)
+  Chef        = Struct.new(:id, :name)
+  Ingredient  = Struct.new(:id, :name)
+
+  let(:doc)               { RecipeDecorator.new(souffle).to_hash }
+  let(:doc_relationships) { doc['data']['relationships'] }
+
+  describe 'non-empty relationships' do
+    let(:souffle) {
+      Recipe.new(1, 'Cheese soufflé',
+                 Chef.new(1, 'Jamie Oliver'),
+                 [Ingredient.new(5, 'Eggs'), Ingredient.new(6, 'Gruyère')])
+    }
+
+    it 'renders a single object for non-empty to-one relationships with custom name' do
+      doc_relationships['best_chef'].must_be_nil
+      doc_relationships['bestChefEver'].wont_be_nil
+    end
+
+    it 'renders an array for non-empty to-many relationships with custom name' do
+      doc_relationships['best_ingredients'].must_be_nil
+      doc_relationships['bestIngridients'].wont_be_nil
+    end
+  end
+end


### PR DESCRIPTION
This fork allows the definition of the `option[:as]` in the has_many declaration in order to enable custom naming of the fields. e.g. camel_case

`has_many :published_variants, as: "publishedVariants", class: ::Product, decorator: ::Concepts::Product::Representer::Teaser`