### PR TITLE
Travis: jruby-9.1.13.0; fix build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2.6
   - 2.3.1
   - 2.4.0
-  - jruby-9.1.6.0
+  - jruby-9.1.13.0
   - ruby-head
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: ruby
 cache: bundler
+before_install:
+  - gem install bundler
 rvm:
   - 1.9.3
   - 2.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
+ruby RUBY_VERSION
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
-git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+git_source(:github) do |repo_name|
+  "https://github.com/#{repo_name}.git"
+end
 
 ruby RUBY_VERSION
 


### PR DESCRIPTION
This PR:

  - keeps 1.9.3 support (annotates `ruby` version in Gemfile, to allow Bundler to navigate to version-compatible gems)
  - avoids Bundler warning about `github` sources
  - uses HTTPS for `rubygems.org`
  - uses [jruby-9.1.13.0](http://jruby.org/2017/09/06/jruby-9-1-13-0.html) in matrix
