### PR TITLE
Use bundler < 2.0 to fix builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: ruby
 cache: bundler
 before_install:
-  - gem install bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 rvm:
   - 1.9
   - 2.1


### PR DESCRIPTION
### Description
This PR changes the `.travis.yml` file to use the latest `1.x` version of `bundler` since from version 2 they dropped support for Ruby versions 2.2 and older ([more info](https://docs.travis-ci.com/user/languages/ruby/#bundler-20)) 