### PR TITLE
Remove usage of deprecated global Minitest expectations

### DIFF
--- a/test/jsonapi/collection_render_test.rb
+++ b/test/jsonapi/collection_render_test.rb
@@ -10,7 +10,7 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
 
   it 'renders full document' do
     json = decorator.to_json
-    json.must_equal_json(%({
+    _(json).must_equal_json(%({
       "data": [{
         "type": "articles",
         "id": "1",
@@ -261,7 +261,7 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
 
   it 'included: false suppresses compound docs' do
     json = decorator.to_json(included: false)
-    json.must_equal_json(%({
+    _(json).must_equal_json(%({
       "data": [{
         "type": "articles",
         "id": "1",
@@ -451,12 +451,12 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
 
   it 'passes :user_options to toplevel links when rendering' do
     hash = decorator.to_hash(user_options: { page: 2, per_page: 10 })
-    hash['links'].must_equal('self' => '//articles?page=2&per_page=10')
+    _(hash['links']).must_equal('self' => '//articles?page=2&per_page=10')
   end
 
   it 'renders extra toplevel meta information if meta option supplied' do
     hash = decorator.to_hash(meta: { page: 2, total: 9 })
-    hash['meta'].must_equal('count' => 3, page: 2, total: 9)
+    _(hash['meta']).must_equal('count' => 3, page: 2, total: 9)
   end
 
   it 'does not render extra meta information on resource objects' do
@@ -467,8 +467,8 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
 
   it 'does not render extra toplevel meta information if meta option is empty' do
     hash = decorator.to_hash(meta: {})
-    hash['meta'][:page].must_be_nil
-    hash['meta'][:total].must_be_nil
+    _(hash['meta'][:page]).must_be_nil
+    _(hash['meta'][:total]).must_be_nil
   end
 
   describe 'Fetching Resources (empty collection)' do
@@ -487,6 +487,6 @@ class JsonapiCollectionRenderTest < MiniTest::Spec
     let(:articles) { [] }
     subject { ArticleDecorator.for_collection.new(articles).to_json }
 
-    it { subject.must_equal_json document }
+    it { _(subject).must_equal_json document }
   end
 end

--- a/test/jsonapi/fieldsets_options_test.rb
+++ b/test/jsonapi/fieldsets_options_test.rb
@@ -13,7 +13,7 @@ class FieldsetsOptionsTest < Minitest::Spec
        { include: 'articles',
          fields:  { 'articles' => 'title,body', 'people' => '' } }].each do |options|
         options = Include.(options, relationships: { 'articles' => 'articles' })
-        options.must_equal(include:  [:id, :attributes, :relationships, :included],
+        _(options).must_equal(include:  [:id, :attributes, :relationships, :included],
                            included: {
                              include:  [:articles],
                              articles: {
@@ -38,7 +38,7 @@ class FieldsetsOptionsTest < Minitest::Spec
        { include: [''] },
        { include: '' }].each do |options|
         options = Include.(options, {})
-        options.must_equal(include:  [:id, :attributes, :relationships, :included],
+        _(options).must_equal(include:  [:id, :attributes, :relationships, :included],
                            included: { include: [] })
       end
     end
@@ -50,7 +50,7 @@ class FieldsetsOptionsTest < Minitest::Spec
        { include: [''], fields:  { articles: ['title,body'],  people: [] } },
        { include: '',   fields:  { 'articles' => 'title,body', 'people' => '' } }].each do |options|
         options = Include.(options, relationships: { '_self' => 'articles' })
-        options.must_equal(include:       [:id, :attributes, :relationships, :included],
+        _(options).must_equal(include:       [:id, :attributes, :relationships, :included],
                            included:      {
                              include: [],
                              people:  {
@@ -69,7 +69,7 @@ class FieldsetsOptionsTest < Minitest::Spec
        { include: [''], fields:  { articles: ['title,body'],  people: ['email'] } },
        { include: '',   fields:  { 'articles' => 'title,body', 'people' => 'email' } }].each do |options|
         options = Include.(options, relationships: { 'author' => 'people', 'articles' => 'articles' })
-        options.must_equal(include:  [:id, :attributes, :relationships, :included],
+        _(options).must_equal(include:  [:id, :attributes, :relationships, :included],
                            included: {
                              include:  [],
                              articles: {
@@ -93,7 +93,7 @@ class FieldsetsOptionsTest < Minitest::Spec
        { include: ['comments'] },
        { include: 'comments' }].each do |options|
         options = Include.(options, {})
-        options.must_equal(include:  [:id, :attributes, :relationships, :included],
+        _(options).must_equal(include:  [:id, :attributes, :relationships, :included],
                            included: {
                              include:  [:comments],
                              comments: {
@@ -109,7 +109,7 @@ class FieldsetsOptionsTest < Minitest::Spec
        { include: ['comments.author.employer'] },
        { include: 'comments.author.employer' }].each do |options|
         options = Include.(options, {})
-        options.must_equal(include:  [:id, :attributes, :relationships, :included],
+        _(options).must_equal(include:  [:id, :attributes, :relationships, :included],
                            included: {
                              include:  [:comments],
                              comments: {
@@ -135,7 +135,7 @@ class FieldsetsOptionsTest < Minitest::Spec
     it 'does not rewrite :include if _json_api_parsed: true' do
       options = Include.({ include:          [:id, :attributes],
                            _json_api_parsed: true }, {})
-      options.must_equal(include:          [:id, :attributes],
+      _(options).must_equal(include:          [:id, :attributes],
                          _json_api_parsed: true)
     end
   end
@@ -143,19 +143,19 @@ class FieldsetsOptionsTest < Minitest::Spec
   describe 'with falsey :include options' do
     it 'does not rewrite include: false' do
       options = Include.({ include: false }, {})
-      options.must_equal(include: false)
+      _(options).must_equal(include: false)
     end
 
     it 'does not rewrite include: nil' do
       options = Include.({ include: nil }, {})
-      options.must_equal(include: nil)
+      _(options).must_equal(include: nil)
     end
   end
 
   describe 'with falsey :fields options' do
     it 'does not parse fields: nil' do
       options = Include.({ fields: nil }, {})
-      options.must_equal(fields: nil)
+      _(options).must_equal(fields: nil)
     end
   end
 end

--- a/test/jsonapi/fieldsets_test.rb
+++ b/test/jsonapi/fieldsets_test.rb
@@ -56,10 +56,10 @@ class JSONAPIFieldsetsTest < Minitest::Spec
     }
 
     it 'includes scalars' do
-      DocumentSingleResourceObjectDecorator.new(article)
+      _(DocumentSingleResourceObjectDecorator.new(article)
                                            .to_json(
                                              fields: { articles: 'title' }
-                                           )
+                                           ))
                                            .must_equal_json(%(
           {
             "data": {
@@ -74,11 +74,11 @@ class JSONAPIFieldsetsTest < Minitest::Spec
     end
 
     it 'includes compound objects' do
-      DocumentSingleResourceObjectDecorator.new(article)
+      _(DocumentSingleResourceObjectDecorator.new(article)
                                            .to_json(
                                              fields:  { articles: 'title' },
                                              include: :comments
-                                           )
+                                           ))
                                            .must_equal_json(%(
           {
             "data": {
@@ -124,11 +124,11 @@ class JSONAPIFieldsetsTest < Minitest::Spec
     end
 
     it 'includes nested compound objects' do
-      DocumentSingleResourceObjectDecorator.new(article)
+      _(DocumentSingleResourceObjectDecorator.new(article)
                                            .to_json(
                                              fields:  { articles: 'title' },
                                              include: 'comments.author'
-                                           )
+                                           ))
                                            .must_equal_json(%(
           {
             "data": {
@@ -184,11 +184,11 @@ class JSONAPIFieldsetsTest < Minitest::Spec
     end
 
     it 'includes other compound objects' do
-      DocumentSingleResourceObjectDecorator.new(article)
+      _(DocumentSingleResourceObjectDecorator.new(article)
                                            .to_json(
                                              fields:  { articles: 'title' },
                                              include: :author
-                                           )
+                                           ))
                                            .must_equal_json(%(
           {
             "data": {
@@ -214,11 +214,11 @@ class JSONAPIFieldsetsTest < Minitest::Spec
 
     describe 'collection' do
       it 'supports :includes' do
-        DocumentSingleResourceObjectDecorator.for_collection.new([article])
+        _(DocumentSingleResourceObjectDecorator.for_collection.new([article])
                                              .to_hash(
                                                fields:  { articles: 'title' },
                                                include: :author
-                                             )
+                                             ))
                                              .must_equal Hash[{
                                                'data'     => [
                                                  { 'type'       => 'articles',
@@ -232,11 +232,11 @@ class JSONAPIFieldsetsTest < Minitest::Spec
 
       # include: ROAR API
       it 'blaaaaaaa' do
-        DocumentSingleResourceObjectDecorator.for_collection.new([article])
+        _(DocumentSingleResourceObjectDecorator.for_collection.new([article])
                                              .to_hash(
                                                fields:  { articles: 'title', authors: [:email] },
                                                include: :author
-                                             )
+                                             ))
                                              .must_equal Hash[{
                                                'data'     => [
                                                  { 'type'       => 'articles',
@@ -282,12 +282,12 @@ class JSONAPIFieldsetsTest < Minitest::Spec
     }
 
     it do
-      CollectionResourceObjectDecorator.for_collection.new([
+      _(CollectionResourceObjectDecorator.for_collection.new([
                                                              Article.new(1, 'My Article', 'An interesting read.'),
                                                              Article.new(2, 'My Other Article', 'An interesting read.')
                                                            ]).to_json(
                                                              fields: { articles: :title }
-                                                           ).must_equal_json document
+                                                           )).must_equal_json document
     end
   end
 
@@ -368,7 +368,7 @@ class JSONAPIFieldsetsTest < Minitest::Spec
     }
 
     it do
-      DocumentResourceWithDifferentIdAtRoot.new(article).to_json(include: 'comments')
+      _(DocumentResourceWithDifferentIdAtRoot.new(article).to_json(include: 'comments'))
                                            .must_equal_json document
     end
   end
@@ -454,7 +454,7 @@ class JSONAPIFieldsetsTest < Minitest::Spec
     }
 
     it do
-      DocumentResourceWithDifferentIdAtRelation.new(article).to_json(include: 'comments')
+      _(DocumentResourceWithDifferentIdAtRelation.new(article).to_json(include: 'comments'))
                                                .must_equal_json document
     end
   end
@@ -540,7 +540,7 @@ class JSONAPIFieldsetsTest < Minitest::Spec
     }
 
     it do
-      DocumentAndRelationWithDifferentId.new(article).to_json(include: 'comments')
+      _(DocumentAndRelationWithDifferentId.new(article).to_json(include: 'comments'))
                                                      .must_equal_json document
     end
   end

--- a/test/jsonapi/member_name_test.rb
+++ b/test/jsonapi/member_name_test.rb
@@ -44,48 +44,48 @@ class MemberNameTest < MiniTest::Spec
 
   describe 'strict (default)' do
     it 'permits alphanumeric ASCII characters, hyphens' do
-      MemberName.('99 Luftballons').must_equal '99luftballons'
-      MemberName.('Artist').must_equal 'artist'
-      MemberName.('Актер').must_equal ''
-      MemberName.('おまかせ').must_equal ''
-      MemberName.('auf-der-bühne').must_equal 'auf-der-bhne'
-      MemberName.('nouvelle_interprétation').must_equal 'nouvelle-interprtation'
+      _(MemberName.('99 Luftballons')).must_equal '99luftballons'
+      _(MemberName.('Artist')).must_equal 'artist'
+      _(MemberName.('Актер')).must_equal ''
+      _(MemberName.('おまかせ')).must_equal ''
+      _(MemberName.('auf-der-bühne')).must_equal 'auf-der-bhne'
+      _(MemberName.('nouvelle_interprétation')).must_equal 'nouvelle-interprtation'
     end
 
     it 'does not permit any reserved characters' do
-      MemberName.(UNICODE_RESERVED_CHARACTERS.join).must_equal ''
+      _(MemberName.(UNICODE_RESERVED_CHARACTERS.join)).must_equal ''
     end
 
     it 'hyphenates underscored words' do
-      MemberName.('playtime_report').must_equal 'playtime-report'
+      _(MemberName.('playtime_report')).must_equal 'playtime-report'
     end
   end
 
   describe 'non-strict' do
     it 'permits alphanumeric unicode characters, hyphens, underscores and spaces' do
-      MemberName.('99 Luftballons', strict: false).must_equal '99 Luftballons'
-      MemberName.('Artist', strict: false).must_equal 'Artist'
-      MemberName.('Актер', strict: false).must_equal 'Актер'
-      MemberName.('おまかせ', strict: false).must_equal 'おまかせ'
-      MemberName.('auf-der-bühne', strict: false).must_equal 'auf-der-bühne'
-      MemberName.('nouvelle_interprétation', strict: false).must_equal 'nouvelle_interprétation'
+      _(MemberName.('99 Luftballons', strict: false)).must_equal '99 Luftballons'
+      _(MemberName.('Artist', strict: false)).must_equal 'Artist'
+      _(MemberName.('Актер', strict: false)).must_equal 'Актер'
+      _(MemberName.('おまかせ', strict: false)).must_equal 'おまかせ'
+      _(MemberName.('auf-der-bühne', strict: false)).must_equal 'auf-der-bühne'
+      _(MemberName.('nouvelle_interprétation', strict: false)).must_equal 'nouvelle_interprétation'
     end
 
     it 'does not permit any reserved characters' do
-      MemberName.(UNICODE_RESERVED_CHARACTERS.join, strict: false).must_equal ''
+      _(MemberName.(UNICODE_RESERVED_CHARACTERS.join, strict: false)).must_equal ''
     end
 
     it 'does not permit hyphens, underscores or spaces at beginning or end' do
-      MemberName.(' 99 Luftballons ', strict: false).must_equal '99 Luftballons'
-      MemberName.('-Artist_', strict: false).must_equal 'Artist'
-      MemberName.('_Актер', strict: false).must_equal 'Актер'
-      MemberName.(' おまかせ', strict: false).must_equal 'おまかせ'
-      MemberName.('-auf-der-bühne', strict: false).must_equal 'auf-der-bühne'
-      MemberName.('nouvelle_interprétation_', strict: false).must_equal 'nouvelle_interprétation'
+      _(MemberName.(' 99 Luftballons ', strict: false)).must_equal '99 Luftballons'
+      _(MemberName.('-Artist_', strict: false)).must_equal 'Artist'
+      _(MemberName.('_Актер', strict: false)).must_equal 'Актер'
+      _(MemberName.(' おまかせ', strict: false)).must_equal 'おまかせ'
+      _(MemberName.('-auf-der-bühne', strict: false)).must_equal 'auf-der-bühne'
+      _(MemberName.('nouvelle_interprétation_', strict: false)).must_equal 'nouvelle_interprétation'
     end
 
     it 'preserves underscored words' do
-      MemberName.('playtime_report', strict: false).must_equal 'playtime_report'
+      _(MemberName.('playtime_report', strict: false)).must_equal 'playtime_report'
     end
   end
 end

--- a/test/jsonapi/post_test.rb
+++ b/test/jsonapi/post_test.rb
@@ -36,12 +36,12 @@ class JsonapiPostTest < MiniTest::Spec
     subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article) }
 
     it do
-      subject.title.must_equal 'Ember Hamster'
-      subject.author.id.must_equal '9'
-      subject.author.email.must_equal '9@nine.to'
+      _(subject.title).must_equal 'Ember Hamster'
+      _(subject.author.id).must_equal '9'
+      _(subject.author.email).must_equal '9@nine.to'
       # subject.author.name.must_be_nil
 
-      subject.comments.must_equal [Comment.new('2'), Comment.new('3')]
+      _(subject.comments).must_equal [Comment.new('2'), Comment.new('3')]
     end
   end
 
@@ -60,7 +60,7 @@ class JsonapiPostTest < MiniTest::Spec
     subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article) }
 
     it do
-      subject.title.must_equal 'Ember Hamster'
+      _(subject.title).must_equal 'Ember Hamster'
     end
   end
 
@@ -72,7 +72,7 @@ class JsonapiPostTest < MiniTest::Spec
     subject { ArticleDecorator.new(Article.new(nil, nil, nil, nil, [])).from_json(post_article) }
 
     it do
-      subject.title.must_be_nil
+      _(subject.title).must_be_nil
     end
   end
 end

--- a/test/jsonapi/relationship_custom_naming_test.rb
+++ b/test/jsonapi/relationship_custom_naming_test.rb
@@ -42,13 +42,13 @@ class RelationshipCustomNameTest < MiniTest::Spec
     }
 
     it 'renders a single object for non-empty to-one relationships with custom name' do
-      doc_relationships['best_chef'].must_be_nil
-      doc_relationships['bestChefEver'].wont_be_nil
+      _(doc_relationships['best_chef']).must_be_nil
+      _(doc_relationships['bestChefEver']).wont_be_nil
     end
 
     it 'renders an array for non-empty to-many relationships with custom name' do
-      doc_relationships['best_ingredients'].must_be_nil
-      doc_relationships['bestIngridients'].wont_be_nil
+      _(doc_relationships['best_ingredients']).must_be_nil
+      _(doc_relationships['bestIngridients']).wont_be_nil
     end
   end
 end

--- a/test/jsonapi/render_test.rb
+++ b/test/jsonapi/render_test.rb
@@ -8,7 +8,7 @@ class JsonapiRenderTest < MiniTest::Spec
 
   it 'renders full document' do
     json = decorator.to_json
-    json.must_equal_json(%({
+    _(json).must_equal_json(%({
       "data": {
         "id": "1",
         "relationships": {
@@ -112,7 +112,7 @@ class JsonapiRenderTest < MiniTest::Spec
 
   it 'included: false suppresses compound docs' do
     json = decorator.to_json(included: false)
-    json.must_equal_json(%({
+    _(json).must_equal_json(%({
       "data": {
         "id": "1",
         "relationships": {
@@ -184,16 +184,16 @@ class JsonapiRenderTest < MiniTest::Spec
     hash = decorator.to_hash(meta: {
                                'copyright' => 'Nick Sutterer', 'reviewers' => []
                              })
-    hash['meta']['copyright'].must_equal('Nick Sutterer')
-    hash['meta']['reviewers'].must_equal([])
-    hash['meta']['reviewer-initials'].must_equal('C.B.')
+    _(hash['meta']['copyright']).must_equal('Nick Sutterer')
+    _(hash['meta']['reviewers']).must_equal([])
+    _(hash['meta']['reviewer-initials']).must_equal('C.B.')
   end
 
   it 'does not render extra toplevel meta information if meta option is empty' do
     hash = decorator.to_hash(meta: {})
-    hash['meta']['copyright'].must_be_nil
-    hash['meta']['reviewers'].must_equal(['Christian Bernstein'])
-    hash['meta']['reviewer-initials'].must_equal('C.B.')
+    _(hash['meta']['copyright']).must_be_nil
+    _(hash['meta']['reviewers']).must_equal(['Christian Bernstein'])
+    _(hash['meta']['reviewer-initials']).must_equal('C.B.')
   end
 
   describe 'Single Resource Object with simple attributes' do
@@ -231,8 +231,8 @@ class JsonapiRenderTest < MiniTest::Spec
       })
     }
 
-    it { DocumentSingleResourceObjectDecorator.new(Article.new(1, 'My Article')).to_json.must_equal_json document }
-    it { DocumentSingleResourceObjectDecorator.for_collection.new([Article.new(1, 'My Article')]).to_json.must_equal_json collection_document }
+    it { _(DocumentSingleResourceObjectDecorator.new(Article.new(1, 'My Article')).to_json).must_equal_json document }
+    it { _(DocumentSingleResourceObjectDecorator.for_collection.new([Article.new(1, 'My Article')]).to_json).must_equal_json collection_document }
   end
 
   describe 'Single Resource Object with complex attributes' do
@@ -307,8 +307,8 @@ class JsonapiRenderTest < MiniTest::Spec
                   %w(Kahnweiler Guernica))
     }
 
-    it { VisualArtistDecorator.new(painter).to_json.must_equal_json document }
-    it { VisualArtistDecorator.for_collection.new([painter]).to_json.must_equal_json collection_document }
+    it { _(VisualArtistDecorator.new(painter).to_json).must_equal_json document }
+    it { _(VisualArtistDecorator.for_collection.new([painter]).to_json).must_equal_json collection_document }
   end
 
 
@@ -371,7 +371,7 @@ class JsonapiRenderTest < MiniTest::Spec
       Painter.new('p1', nil, [], nil, [], nil)
     }
 
-    it { ArtistDecorator.new(painter).to_json.must_equal_json document }
-    it { ArtistDecorator.for_collection.new([painter]).to_json.must_equal_json collection_document }
+    it { _(ArtistDecorator.new(painter).to_json).must_equal_json document }
+    it { _(ArtistDecorator.for_collection.new([painter]).to_json).must_equal_json collection_document }
   end
 end

--- a/test/jsonapi/resource_linkage_test.rb
+++ b/test/jsonapi/resource_linkage_test.rb
@@ -55,11 +55,11 @@ class ResourceLinkageTest < MiniTest::Spec
     }
 
     it 'renders a single object for non-empty to-one relationships' do
-      doc_relationships['chef'].must_equal('data'=>{ 'type' => 'chefs', 'id' => '1' })
+      _(doc_relationships['chef']).must_equal('data'=>{ 'type' => 'chefs', 'id' => '1' })
     end
 
     it 'renders an array for non-empty to-many relationships' do
-      doc_relationships['ingredients'].must_equal('data' => [
+      _(doc_relationships['ingredients']).must_equal('data' => [
                                                     { 'type' => 'ingredients', 'id' => '5' },
                                                     { 'type' => 'ingredients', 'id' => '6' }
                                                   ])
@@ -70,11 +70,11 @@ class ResourceLinkageTest < MiniTest::Spec
     let(:souffle) { Recipe.new(1, 'Cheese soufflé', nil, nil) }
 
     it 'renders null for an empty to-one relationships' do
-      doc_relationships['chef'].must_equal('data' => nil)
+      _(doc_relationships['chef']).must_equal('data' => nil)
     end
 
     it 'renders an empty array ([]) for empty (nil) to-many relationships' do
-      doc_relationships['ingredients'].must_equal('data' => [])
+      _(doc_relationships['ingredients']).must_equal('data' => [])
     end
   end
 
@@ -82,7 +82,7 @@ class ResourceLinkageTest < MiniTest::Spec
     let(:souffle) { Recipe.new(1, 'Cheese soufflé', nil, []) }
 
     it 'renders an empty array ([]) for empty to-many relationships' do
-      doc_relationships['ingredients'].must_equal('data' => [])
+      _(doc_relationships['ingredients']).must_equal('data' => [])
     end
   end
 end


### PR DESCRIPTION
Minitest is not going to monkey patch all objects anymore:

https://github.com/minitest/minitest/commit/e6bc4485730403faff6966c1671cf5de72b2d233

See also RuboCop's [Minitest/GlobalExpectations](https://docs.rubocop.org/rubocop-minitest/cops_minitest.html#minitestglobalexpectations).